### PR TITLE
release/public-v1: add flags to compile with gfortran-10

### DIFF
--- a/sorc/copygb2.fd/CMakeLists.txt
+++ b/sorc/copygb2.fd/CMakeLists.txt
@@ -6,6 +6,11 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 endif()
 
+# For gfortran-10+ backward compatibility
+if(${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER 9.9)
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -w -fallow-argument-mismatch")
+endif()
+
 set(fortran_src
     copygb2.f
     polates1.f90


### PR DESCRIPTION
gfortran-10 is much stricter than previous versions of gfortran. This PR adds flags to compile the code with fortran-10 to the release/public-v1 branch. Unfortunately, due to the way the release/public-v1 builds are set up, this needs to be done for each of the NCEPLIBS-* directories that need the additional flags.

Tested to work on macOS with gfortran-10.2.0. Tested to have no impact on machines with Intel compilers or older GNU compilers.