### PR TITLE
Give all target_link_libraries explicit PRIVATE signatures

### DIFF
--- a/sorc/copygb2.fd/CMakeLists.txt
+++ b/sorc/copygb2.fd/CMakeLists.txt
@@ -21,8 +21,7 @@ set(fortran_src
 
 set(exe_name copygb2)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(
-  ${exe_name}
+target_link_libraries(${exe_name} PRIVATE
   g2::g2_d
   PNG::PNG
   ${JASPER_LIBRARIES}

--- a/sorc/degrib2.fd/CMakeLists.txt
+++ b/sorc/degrib2.fd/CMakeLists.txt
@@ -10,8 +10,7 @@ set(fortran_src degrib2.f prlevel.f prvtime.f)
 
 set(exe_name degrib2)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(
-  ${exe_name}
+target_link_libraries(${exe_name} PRIVATE
   g2::g2_4
   w3nco::w3nco_4
   bacio::bacio_4

--- a/sorc/grb2index.fd/CMakeLists.txt
+++ b/sorc/grb2index.fd/CMakeLists.txt
@@ -10,6 +10,6 @@ set(fortran_src grb2index.f)
 
 set(exe_name grb2index)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} g2::g2_4 w3nco::w3nco_4 bacio::bacio_4)
+target_link_libraries(${exe_name} PRIVATE g2::g2_4 w3nco::w3nco_4 bacio::bacio_4)
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)

--- a/sorc/grbindex.fd/CMakeLists.txt
+++ b/sorc/grbindex.fd/CMakeLists.txt
@@ -11,6 +11,6 @@ set(fortran_src grbindex.f)
 
 set(exe_name grbindex)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} w3nco::w3nco_4 bacio::bacio_4)
+target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_4 bacio::bacio_4)
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)

--- a/sorc/grib2grib.fd/CMakeLists.txt
+++ b/sorc/grib2grib.fd/CMakeLists.txt
@@ -11,6 +11,6 @@ set(fortran_src grib2grib.f hexchar.f)
 
 set(exe_name grib2grib)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} w3nco::w3nco_8 bacio::bacio_8)
+target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_8 bacio::bacio_8)
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)

--- a/sorc/tocgrib.fd/CMakeLists.txt
+++ b/sorc/tocgrib.fd/CMakeLists.txt
@@ -10,6 +10,6 @@ set(fortran_src makwmo.f mkfldsep.f tocgrib.f)
 
 set(exe_name tocgrib)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} w3nco::w3nco_4 bacio::bacio_4)
+target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_4 bacio::bacio_4)
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)

--- a/sorc/tocgrib2super.fd/CMakeLists.txt
+++ b/sorc/tocgrib2super.fd/CMakeLists.txt
@@ -10,8 +10,7 @@ set(fortran_src makwmo.f tocgrib2super.f)
 
 set(exe_name tocgrib2super)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(
-  ${exe_name}
+target_link_libraries(${exe_name} PRIVATE
   g2::g2_4
   w3nco::w3nco_4
   bacio::bacio_4

--- a/sorc/wgrib.cd/CMakeLists.txt
+++ b/sorc/wgrib.cd/CMakeLists.txt
@@ -12,6 +12,6 @@ set(c_src wgrib.c)
 
 set(exe_name wgrib)
 add_executable(${exe_name} ${c_src})
-target_link_libraries(${exe_name} w3nco::w3nco_4 bacio::bacio_4)
+target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_4 bacio::bacio_4)
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)


### PR DESCRIPTION
The two signatures (with and without) don't mix and throws an error. 

The failure showed up in my hpc-stack test branch https://github.com/kgerheiser/hpc-stack/runs/1063897395?check_suite_focus=true

I didn't change that part of hpc-stack at all though, and it builds on my computer and the main repo.

It's good for everything to be consistent, anyway.


I now believe it's caused by OpenMP. Even though it's not in grib_util, it's on in SP which adds a `target_link_library( PRIVATE OpenMP)` somewhere in the background which conflicts with the one that doesn't have any scope signature. 
