### PR TITLE
Fix library linking for copygb and remove unneeded libs for wgrib

### DIFF
--- a/sorc/copygb.fd/CMakeLists.txt
+++ b/sorc/copygb.fd/CMakeLists.txt
@@ -10,7 +10,7 @@ set(fortran_src copygb.F)
 
 set(exe_name copygb)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} PRIVATE bacio::bacio_4 w3nco::w3nco_4 ip::ip_4 sp::sp_4)
+target_link_libraries(${exe_name} PRIVATE bacio::bacio_4 w3nco::w3nco_d ip::ip_d sp::sp_d)
 
 if(OpenMP_Fortran_FOUND)
   target_link_libraries(${exe_name} PRIVATE OpenMP::OpenMP_Fortran)

--- a/sorc/wgrib.cd/CMakeLists.txt
+++ b/sorc/wgrib.cd/CMakeLists.txt
@@ -12,6 +12,5 @@ set(c_src wgrib.c)
 
 set(exe_name wgrib)
 add_executable(${exe_name} ${c_src})
-target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_4 bacio::bacio_4)
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)


### PR DESCRIPTION
Use _d (real64, int32) versions of w3nco, ip, and sp for copygb instead of _4

Remove un-used libraries for wgrib

Went through each of the executables and checked their libraries and copygb was the only one affected. wgrib does not use external libraries and the `target_link_libraries` can be removed.

Could you give this a try @GeorgeVandenberghe-NOAA?

Fix #54 