### PR TITLE
deal with name change of bacio library in bacio-2.5.0 release

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         repository: jasper-software/jasper
         path: jasper
-        ref: version-2.0.22
+        ref: version-2.0.33
 
     - name: build-jasper
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,19 +22,33 @@ endif()
 
 include(GNUInstallDirs)
 
+# Find openMP if we need it.
 if(OPENMP)
   find_package(OpenMP REQUIRED COMPONENTS Fortran)
 endif()
 
-find_package(Jasper REQUIRED)
+# Find these required compression libraries.
+find_package(Jasper 2.0.25 REQUIRED)
 find_package(PNG REQUIRED)
 find_package(ZLIB REQUIRED)
 
-find_package(w3nco REQUIRED)
-find_package(g2 REQUIRED)
-find_package(bacio REQUIRED)
-find_package(ip REQUIRED)
-find_package(sp REQUIRED)
+# Find the NCEPLIBS libraries we need.
+find_package(w3nco 2.4.0 REQUIRED)
+find_package(g2 3.4.0 REQUIRED)
+find_package(bacio 2.4.0 REQUIRED)
+find_package(ip 3.3.3 REQUIRED)
+find_package(sp 2.3.3 REQUIRED)
+
+# The name of the bacio library changed with the 2.5.0 release. The
+# "_4" was removed from the library and include directory name in the
+# bacio-2.5.0 release. Set a name variable to be used in the rest of
+# the cmake build.
+if(bacio_VERSION GREATER_EQUAL 2.5.0)
+  set(bacio_name bacio)
+else()
+  set(bacio_name bacio_4)
+endif()
+message(STATUS "Using bacio library ${bacio_name}")
 
 add_subdirectory(sorc)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/.
 
 NCEP/EMC developers.
 
-Code Manager : Boi Vuong
+Code Manager : Hang Lei, Edward Hartnett
 
 ## Prerequisites
 
@@ -33,7 +33,7 @@ This package requires the folling NCEPLIBS libraries:
 ```
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/path/to/install /path/to/NCEPLIBS-grib_util
+cmake -DCMAKE_INSTALL_PREFIX=/path/to/install -DCMAKE_PREFIX_PATH=/path/to/dependencies ..
 make -j4
 make install
 ```

--- a/sorc/cnvgrib.fd/CMakeLists.txt
+++ b/sorc/cnvgrib.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake file for the cnvgrib utility of the
+# NCEPLIBS-grib_util project.
+#
+# Mark Potts, Kyle Gerheiser
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS "-g")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
@@ -6,28 +11,14 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 endif()
 
-set(fortran_src
-    cnv12.f
-    cnv22.f
-    gds2gdt.f
-    makepdsens.f
-    pds2pdtens.f
-    putgbexn.f
-    cnv21.f
-    cnvgrib.f
-    gdt2gds.f
-    makepds.f
-    pds2pdt.f
+set(fortran_src cnv12.f cnv22.f gds2gdt.f makepdsens.f pds2pdtens.f
+    putgbexn.f cnv21.f cnvgrib.f gdt2gds.f makepds.f pds2pdt.f
     setbit.f)
 
 set(exe_name cnvgrib)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} PRIVATE
-  g2::g2_4
-  bacio::bacio_4
-  w3nco::w3nco_4
-  ${JASPER_LIBRARIES}
-  PNG::PNG
+target_link_libraries(${exe_name} PRIVATE g2::g2_4
+  bacio::${bacio_name} w3nco::w3nco_4 ${JASPER_LIBRARIES} PNG::PNG
   ${ZLIB_LIBRARY})
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)

--- a/sorc/copygb.fd/CMakeLists.txt
+++ b/sorc/copygb.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake build file for the copygb utility in the
+# NCEPLIBS-grib_util project.
+#
+# George Gayno, Mark Potts
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS "-g -r8 -auto")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
@@ -10,7 +15,7 @@ set(fortran_src copygb.F)
 
 set(exe_name copygb)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} PRIVATE bacio::bacio_4 w3nco::w3nco_d ip::ip_d sp::sp_d)
+target_link_libraries(${exe_name} PRIVATE bacio::${bacio_name} w3nco::w3nco_d ip::ip_d sp::sp_d)
 
 if(OpenMP_Fortran_FOUND)
   target_link_libraries(${exe_name} PRIVATE OpenMP::OpenMP_Fortran)

--- a/sorc/copygb2.fd/CMakeLists.txt
+++ b/sorc/copygb2.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake build file for the copygb2 utility in the
+# NCEPLIBS-grib_util project.
+#
+# Mark Potts, Kyle Gerheiser
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS "-g -r8 -auto -convert big_endian -fpp")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
@@ -25,7 +30,7 @@ target_link_libraries(${exe_name} PRIVATE
   g2::g2_d
   PNG::PNG
   ${JASPER_LIBRARIES}
-  bacio::bacio_4
+  bacio::${bacio_name}
   w3nco::w3nco_d
   ip::ip_d
   sp::sp_d)

--- a/sorc/degrib2.fd/CMakeLists.txt
+++ b/sorc/degrib2.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake build file for the degrib2 utility in the
+# NCEPLIBS-grib_util project.
+#
+# George Gayno, Mark Potts
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS "-g -convert big_endian -axCORE-AVX2 -fpp")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
@@ -13,7 +18,7 @@ add_executable(${exe_name} ${fortran_src})
 target_link_libraries(${exe_name} PRIVATE
   g2::g2_4
   w3nco::w3nco_4
-  bacio::bacio_4
+  bacio::${bacio_name}
   PNG::PNG
   ${JASPER_LIBRARIES}
   ${ZLIB_LIBRARY})

--- a/sorc/grb2index.fd/CMakeLists.txt
+++ b/sorc/grb2index.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake build file for the grb2index utility in the
+# NCEPLIBS-grib_util project.
+#
+# Mark Potts, Kyle Gerheiser
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS "-g -convert big_endian -axCORE-AVX2 -fpp")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
@@ -10,6 +15,6 @@ set(fortran_src grb2index.f)
 
 set(exe_name grb2index)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} PRIVATE g2::g2_4 w3nco::w3nco_4 bacio::bacio_4)
+target_link_libraries(${exe_name} PRIVATE g2::g2_4 w3nco::w3nco_4 bacio::${bacio_name})
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)

--- a/sorc/grbindex.fd/CMakeLists.txt
+++ b/sorc/grbindex.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake build file for the grbindex utility in the
+# NCEPLIBS-grib_util project.
+#
+# George Gayno, Mark Potts
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS
       "-g -assume noold_ldout_format -convert big_endian -axCORE-AVX2 -fpp")
@@ -11,6 +16,6 @@ set(fortran_src grbindex.f)
 
 set(exe_name grbindex)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_4 bacio::bacio_4)
+target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_4 bacio::${bacio_name})
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)

--- a/sorc/grib2grib.fd/CMakeLists.txt
+++ b/sorc/grib2grib.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake file for the grib2grib utility of the
+# NCEPLIBS-grib_util project.
+#
+# Mark Potts, Kyle Gerheiser
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS
       "-g -i8 -r8 -assume noold_ldout_format -axCORE-AVX2 -fpp")
@@ -11,6 +16,6 @@ set(fortran_src grib2grib.f hexchar.f)
 
 set(exe_name grib2grib)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_8 bacio::bacio_8)
+target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_8 bacio::${bacio_name})
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)

--- a/sorc/tocgrib.fd/CMakeLists.txt
+++ b/sorc/tocgrib.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake build file for the tocgrib utility in the
+# NCEPLIBS-grib_util project.
+#
+# Mark Potts, Kyle Gerheiser
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS "-g -assume noold_ldout_format -axCORE-AVX2")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
@@ -10,6 +15,6 @@ set(fortran_src makwmo.f mkfldsep.f tocgrib.f)
 
 set(exe_name tocgrib)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_4 bacio::bacio_4)
+target_link_libraries(${exe_name} PRIVATE w3nco::w3nco_4 bacio::${bacio_name})
 
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)

--- a/sorc/tocgrib2.fd/CMakeLists.txt
+++ b/sorc/tocgrib2.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake build file for the tocgrib2 utility in the
+# NCEPLIBS-grib_util project.
+#
+# Mark Potts, Kyle Gerheiser
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS "-g -axCORE-AVX2")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
@@ -14,7 +19,7 @@ target_link_libraries(
   ${exe_name}
   g2::g2_4
   w3nco::w3nco_4
-  bacio::bacio_4
+  bacio::${bacio_name}
   PNG::PNG
   ${JASPER_LIBRARIES}
   ${ZLIB_LIBRARY})

--- a/sorc/tocgrib2super.fd/CMakeLists.txt
+++ b/sorc/tocgrib2super.fd/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake build file for the togrib2super utility in the
+# NCEPLIBS-grib_util project.
+#
+# Mark Potts, Kyle Gerheiser
+
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
   set(CMAKE_Fortran_FLAGS "-g -assume noold_ldout_format -axCORE-AVX2")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
@@ -13,7 +18,7 @@ add_executable(${exe_name} ${fortran_src})
 target_link_libraries(${exe_name} PRIVATE
   g2::g2_4
   w3nco::w3nco_4
-  bacio::bacio_4
+  bacio::${bacio_name}
   PNG::PNG
   ${JASPER_LIBRARIES}
   ${ZLIB_LIBRARY})


### PR DESCRIPTION
In this PR I deal with name change of bacio library in bacio-2.5.0 release. Also add minimum versions to some utilities, taking the minimum versions from UFS_UTILS.

Fixes #61 
Fixes #62 