### PR TITLE
Change gbyte to g2_gbytec in cnvgrib

### DIFF
--- a/src/cnvgrib/cnv12.F90
+++ b/src/cnvgrib/cnv12.F90
@@ -126,7 +126,7 @@ subroutine cnv12(ifl1, ifl2, ipack, usemiss, imiss, uvvect, table_ver)
         ensemble = .true.
      endif
      if (ensemble) then    ! ensemble forecast
-        call gbyte(cgribin(9), ilast, 0, 24)
+        call g2_gbytec(cgribin(9), ilast, 0, 24)
         call pdseup(kens, kprob, xprob, kclust, kmembr, ilast, cgribin(9))
         if (kens(2) .eq. 1) listsec1(13) = 3
         if (kens(2) .eq. 2 .OR. kens(2) .eq. 3) listsec1(13) = 4


### PR DESCRIPTION
gbyte comes from w3emc and operates on words, while g2_gbytec operates on individual bytes and is how cnvgrib passes arguments to the function. gbytec originally came from g2, but the name was changed to g2_gbytec, and w3emc happened to have the same function name, so no error was generated about a missing symbol. This function is only called when using an ensemble template, so it was never noticed.

Fix #138