### PR TITLE
change version of g2 used in CI from develop to 3.4.5

### DIFF
--- a/.github/workflows/develop_test.yml
+++ b/.github/workflows/develop_test.yml
@@ -8,6 +8,18 @@ jobs:
       FC: gfortran-9
       CC: gcc-9
 
+    strategy:
+      fail-fast: false
+      matrix:
+        g2-branch:
+        - {
+            name: "v3.4.5",
+            branch: "v3.4.5"
+          }
+        - {
+            name: "develop",
+            branch: "develop"
+          }
     steps:
     - name: install-dependencies
       run: |
@@ -106,7 +118,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-g2
         path: g2
-        ref: v3.4.5
+        ref: ${{ matrix.g2_branch.branch }}
 
     - name: build-g2
       run: |

--- a/.github/workflows/develop_test.yml
+++ b/.github/workflows/develop_test.yml
@@ -16,10 +16,10 @@ jobs:
             name: "v3.4.5",
             branch: "v3.4.5"
           }
-        - {
-            name: "develop",
-            branch: "develop"
-          }
+        # - {
+        #     name: "develop",
+        #     branch: "develop"
+        #   }
     steps:
     - name: install-dependencies
       run: |

--- a/.github/workflows/develop_test.yml
+++ b/.github/workflows/develop_test.yml
@@ -118,7 +118,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-g2
         path: g2
-        ref: ${{ matrix.g2_branch.branch }}
+        ref: v3.4.5
 
     - name: build-g2
       run: |

--- a/.github/workflows/develop_test.yml
+++ b/.github/workflows/develop_test.yml
@@ -106,7 +106,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-g2
         path: g2
-        ref: develop
+        ref: v3.4.5
 
     - name: build-g2
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ find_package(sp 2.3.3 REQUIRED)
 find_package(ip 3.3.3 REQUIRED)
 find_package(w3emc 2.9.2 REQUIRED)
 find_package(g2 3.4.0 REQUIRED)
+if(g2_VERSION GREATER_EQUAL 3.5.0)
+  find_package(g2c 1.6.4 REQUIRED)
+endif()
 
 # The name of the bacio library changed with the 2.5.0 release. The
 # "_4" was removed from the library and include directory name in the

--- a/src/cnvgrib/CMakeLists.txt
+++ b/src/cnvgrib/CMakeLists.txt
@@ -23,9 +23,13 @@ message(STATUS "In cnvgrib ${JASPER_LIBRARIES}")
 message(STATUS "In cnvgrib ${ZLIB_LIBRARIES}")
 set(exe_name cnvgrib)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} g2::g2_4
+set(link_libs g2::g2_4 
   bacio::${bacio_name} w3emc::w3emc_4 ${JASPER_LIBRARIES} PNG::PNG
   ${ZLIB_LIBRARY})
+if(g2_VERSION GREATER_EQUAL 3.5.0)
+  set(link_libs g2c::g2c ${link_libs})
+endif()
+target_link_libraries(${exe_name} ${link_libs})
 
 # Install cnvgrib.
 install(TARGETS ${exe_name} RUNTIME DESTINATION bin)


### PR DESCRIPTION
Part of #155.

In this PR I change the CI to use version 3.4.5 of g2 instead of the develop branch.
