### PR TITLE
now testing with g2c_compare utility

### DIFF
--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -21,7 +21,7 @@ jobs:
       CC: gcc-11
     strategy:
       matrix:
-        g2-version: [develop, 3.4.x]
+        g2-version: [develop, v3.4.x]
         bacio-version: [2.5.0]
         jasper-version: [2.0.33, 3.0.5]
         w3emc-version: [2.9.3]
@@ -155,23 +155,15 @@ jobs:
         make -j2
         make install
           
-    - name: cache-g2
-      id: cache-g2
-      uses: actions/cache@v2
-      with:
-        path: ~/g2
-        key: g2-${{ runner.os }}-${{ matrix.bacio-version }}-${{ matrix.jasper-version }}-${{ matrix.w3emc-version }}-${{ matrix.g2-version }}
-
     - name: checkout-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: NOAA-EMC/NCEPLIBS-g2
         path: g2
-        ref: v${{ matrix.g2-version }}
+        ref: ${{ matrix.g2-version }}
 
     - name: build-g2
-      if: steps.cache-g2.outputs.cache-hit != 'true'
       run: |
         cd g2
         mkdir build

--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         g2-version: [develop, v3.4.x]
         bacio-version: [2.5.0]
-        jasper-version: [2.0.33, 3.0.5]
+        jasper-version: [2.0.33, 3.0.5, 4.0.0]
         w3emc-version: [2.9.3]
 
     steps:

--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -197,6 +197,6 @@ jobs:
       run: |
         cd grib_utils
         mkdir build && cd build
-        cmake -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/sp;~/ip;~/w3emc;~/g2" ..
+        cmake -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/sp;~/ip;~/w3emc;~/g2;~/g2c" ..
         make -j2 VERBOSE=1
         ctest --output-on-failure --rerun-failed --verbose

--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -4,7 +4,7 @@
 # different versions jasper.
 #
 # Ed Hartnett 1/19/23
-name: Linux_versions
+name: Linux_external
 on:
   push:
     branches:
@@ -14,7 +14,7 @@ on:
     - develop
 
 jobs:
-  Linux_versions:
+  Linux_external:
     runs-on: ubuntu-latest
     env:
       FC: gfortran-11
@@ -155,6 +155,22 @@ jobs:
         make -j2
         make install
           
+    - name: checkout-g2c
+      uses: actions/checkout@v2
+      with:
+        repository: NOAA-EMC/NCEPLIBS-g2c
+        path: g2c
+        ref: develop
+
+    - name: build-g2c
+      run: |
+        cd g2c
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=~/g2c -DCMAKE_PREFIX_PATH="~/jasper" ..
+        make -j2
+        make install
+                 
     - name: checkout-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
@@ -168,7 +184,7 @@ jobs:
         cd g2
         mkdir build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=~/g2 -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/w3emc" ..
+        cmake -DCMAKE_INSTALL_PREFIX=~/g2 -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/w3emc;~/g2c" ..
         make -j2
         make install
                  

--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -1,0 +1,194 @@
+# This is a GitHub actions workflow for the NCEPLIBS-grib_util project.
+#
+# This workflow builds on Linux with latest versions of NCEPLIBS and
+# different versions jasper.
+#
+# Ed Hartnett 1/19/23
+name: Linux_versions
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+jobs:
+  Linux_versions:
+    runs-on: ubuntu-latest
+    env:
+      FC: gfortran-11
+      CC: gcc-11
+    strategy:
+      matrix:
+        g2-version: [develop, 3.4.x]
+        bacio-version: [2.5.0]
+        jasper-version: [2.0.33, 3.0.5]
+        w3emc-version: [2.9.3]
+
+    steps:
+    - name: install-dependencies
+      run: |
+        sudo apt-get update &> /dev/null
+        sudo apt-get install libpng-dev libjpeg-dev 
+          
+    - name: cache-jasper
+      id: cache-jasper
+      uses: actions/cache@v2
+      with:
+        path: ~/jasper
+        key: jasper-Linux_versions-${{ matrix.jasper-version }}
+
+    - name: checkout-jasper
+      if: steps.cache-jasper.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: jasper-software/jasper
+        path: jasper
+        ref: version-${{ matrix.jasper-version }}
+
+    - name: build-jasper
+      if: steps.cache-jasper.outputs.cache-hit != 'true'
+      run: |
+        cd jasper
+        mkdir b && cd b
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/jasper
+        make -j2
+        make install
+
+    - name: cache-bacio
+      id: cache-bacio
+      uses: actions/cache@v2
+      with:
+        path: ~/bacio
+        key: bacio-${{ runner.os }}-v${{ matrix.bacio-version }}
+
+    - name: checkout-bacio
+      if: steps.cache-bacio.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: NOAA-EMC/NCEPLIBS-bacio
+        path: bacio
+        ref: v${{ matrix.bacio-version }}
+    
+    - name: build-bacio
+      if: steps.cache-bacio.outputs.cache-hit != 'true'
+      run: |
+        cd bacio
+        mkdir build && cd build
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/bacio
+        make -j2
+        make install
+
+    - name: cache-sp
+      id: cache-sp
+      uses: actions/cache@v2
+      with:
+        path: ~/sp
+        key: sp-${{ runner.os }}-2.3.3-1
+
+    - name: checkout-sp
+      if: steps.cache-sp.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: NOAA-EMC/NCEPLIBS-sp
+        path: sp
+        ref: v2.3.3
+
+    - name: build-sp
+      if: steps.cache-sp.outputs.cache-hit != 'true'
+      run: |
+        cd sp
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/sp
+        make -j2
+        make install
+          
+    - name: cache-w3emc
+      id: cache-w3emc
+      uses: actions/cache@v2
+      with:
+        path: ~/w3emc
+        key: w3emc-${{ runner.os }}-${{ matrix.w3emc-version }}-bacio-${{ matrix.bacio-version }}
+
+    - name: checkout-w3emc
+      if: steps.cache-w3emc.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: NOAA-EMC/NCEPLIBS-w3emc
+        path: w3emc
+        ref: v${{ matrix.w3emc-version }}
+
+    - name: build-w3emc
+      if: steps.cache-w3emc.outputs.cache-hit != 'true'
+      run: |
+        cd w3emc
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_PREFIX_PATH=~/bacio -DCMAKE_INSTALL_PREFIX=~/w3emc
+        make -j2
+        make install
+          
+    - name: cache-ip
+      id: cache-ip
+      uses: actions/cache@v2
+      with:
+        path: ~/ip
+        key: ip-${{ runner.os }}-3.3.3
+
+    - name: checkout-ip
+      if: steps.cache-ip.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: NOAA-EMC/NCEPLIBS-ip
+        path: ip
+        ref: v3.3.3
+
+    - name: build-ip
+      if: steps.cache-ip.outputs.cache-hit != 'true'
+      run: |
+        cd ip
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/ip -DCMAKE_PREFIX_PATH=~/sp
+        make -j2
+        make install
+          
+    - name: cache-g2
+      id: cache-g2
+      uses: actions/cache@v2
+      with:
+        path: ~/g2
+        key: g2-${{ runner.os }}-${{ matrix.bacio-version }}-${{ matrix.jasper-version }}-${{ matrix.w3emc-version }}-${{ matrix.g2-version }}
+
+    - name: checkout-g2
+      if: steps.cache-g2.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: NOAA-EMC/NCEPLIBS-g2
+        path: g2
+        ref: v${{ matrix.g2-version }}
+
+    - name: build-g2
+      if: steps.cache-g2.outputs.cache-hit != 'true'
+      run: |
+        cd g2
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=~/g2 -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/w3emc" ..
+        make -j2
+        make install
+                 
+    - name: checkout-grib_utils
+      uses: actions/checkout@v2
+      with: 
+        path: grib_utils
+
+    - name: build-grib_utils
+      run: |
+        cd grib_utils
+        mkdir build && cd build
+        cmake -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/sp;~/ip;~/w3emc;~/g2" ..
+        make -j2 VERBOSE=1
+        ctest --output-on-failure --rerun-failed --verbose

--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -197,6 +197,8 @@ jobs:
       run: |
         cd grib_utils
         mkdir build && cd build
+        export LD_LIBRARY_PATH=/home/runner/jasper/lib
+        export PATH="~/g2c/bin:$PATH"
         cmake -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/sp;~/ip;~/w3emc;~/g2;~/g2c" ..
         make -j2 VERBOSE=1
         ctest --output-on-failure --rerun-failed --verbose

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         g2-version: [3.4.5, 3.4.x]
         bacio-version: [2.4.1, 2.5.0]
-        jasper-version: [2.0.33]
+        jasper-version: [2.0.33, 3.0.5, 4.0.0]
         w3emc-version: [2.9.3]
 
     steps:

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -22,8 +22,9 @@ jobs:
     strategy:
       matrix:
         g2-version: [3.4.5, 3.4.x]
-        bacio-version: [2.4.1, 2.5.0]
-        jasper-version: [2.0.33, 3.0.5, 4.0.0]
+#        bacio-version: [2.4.1, 2.5.0]
+        bacio-version: [2.5.0]
+        jasper-version: [2.0.33, 3.0.5]
         w3emc-version: [2.9.3]
 
     steps:

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -24,7 +24,7 @@ jobs:
         g2-version: [3.4.5, 3.4.x]
         bacio-version: [2.4.1, 2.5.0]
         jasper-version: [2.0.33]
-        w3emc-version: [2.9.3]
+        w3emc-version: [2.9.2, 2.9.3]
 
     steps:
     - name: install-dependencies

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       matrix:
         g2-version: [3.4.5, 3.4.x]
-#        bacio-version: [2.4.1, 2.5.0]
+        bacio-version: [2.4.1, 2.5.0]
         bacio-version: [2.5.0]
-        jasper-version: [2.0.33, 3.0.5]
+        jasper-version: [2.0.33]
         w3emc-version: [2.9.3]
 
     steps:

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         g2-version: [3.4.5, 3.4.x]
         bacio-version: [2.4.1, 2.5.0]
-        jasper-version: [4.0.0]
+        jasper-version: [2.0.33]
         w3emc-version: [2.9.3]
 
     steps:

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         g2-version: [3.4.5, 3.4.x]
         bacio-version: [2.4.1, 2.5.0]
-        bacio-version: [2.5.0]
         jasper-version: [2.0.33]
         w3emc-version: [2.9.3]
 

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         g2-version: [3.4.5, 3.4.x]
         bacio-version: [2.4.1, 2.5.0]
-        jasper-version: [2.0.33]
-        w3emc-version: [2.9.2, 2.9.3]
+        jasper-version: [4.0.0]
+        w3emc-version: [2.9.3]
 
     steps:
     - name: install-dependencies

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -156,6 +156,7 @@ jobs:
         mkdir build
         cd build
         echo $LD_LIBRARY_PATH
+        export PATH="~/g2c/bin:$PATH"
         pwd
         cmake -DCMAKE_INSTALL_PREFIX=~/g2 -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/w3emc;~/g2c" ..
         make -j2

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -160,6 +160,7 @@ jobs:
         mkdir build && cd build
         ls -l ~/jasper/lib
         export LD_LIBRARY_PATH=/home/runner/jasper/lib
+        export PATH="/home/runner/g2c/bin/g2c_compare:$PATH"
         cmake -DENABLE_DOCS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/sp;~/ip;~/w3emc;~/g2;~/g2c" -DCMAKE_Fortran_FLAGS="-fprofile-arcs -ftest-coverage -O0 -Wall" -DCMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage -O0 -Wall" ..
         make -j2 VERBOSE=1
         ctest --output-on-failure --rerun-failed --verbose

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -172,7 +172,7 @@ jobs:
         mkdir build && cd build
         ls -l ~/jasper/lib
         export LD_LIBRARY_PATH=/home/runner/jasper/lib
-        export PATH="/home/runner/g2c/bin/g2c_compare:$PATH"
+        export PATH="~/g2c/bin:$PATH"
         cmake -DENABLE_DOCS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/sp;~/ip;~/w3emc;~/g2;~/g2c" -DCMAKE_Fortran_FLAGS="-fprofile-arcs -ftest-coverage -O0 -Wall" -DCMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage -O0 -Wall" ..
         make -j2 VERBOSE=1
         ctest --output-on-failure --rerun-failed --verbose

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -1,15 +1,18 @@
+# This is a GitHub actions CI workflow for the NCEPLIBS-grib_util
+# project.
+#
+# This workflow tests the build as a developer would do it, with
+# address sanitizer and documentation build.
+#
+# Ed Hartnett 1/9/23
 name: developer
 on:
   push:
     branches:
     - develop
-    paths-ignore:
-    - README.md
   pull_request:
     branches:
     - develop
-    paths-ignore:
-    - README.md
 
 jobs:
   developer:
@@ -67,14 +70,23 @@ jobs:
         make -j2
         make install
 
+    - name: cache-sp
+      id: cache-sp
+      uses: actions/cache@v2
+      with:
+        path: ~/sp
+        key: sp-developer-${{ runner.os }}-2.3.3
+
     - name: checkout-sp
+      if: steps.cache-sp.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: NOAA-EMC/NCEPLIBS-sp
         path: sp
-        ref: develop
+        ref: v2.3.3
 
     - name: build-sp
+      if: steps.cache-sp.outputs.cache-hit != 'true'
       run: |
         cd sp
         mkdir build

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         repository: jasper-software/jasper
         path: jasper
-        ref: version-2.0.33
+        ref: version-3.0.5
 
     - name: cache-jasper
       id: cache-jasper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,16 @@ find_package(w3emc 2.9.2 REQUIRED)
 find_package(g2 3.4.0 REQUIRED)
 if (g2_VERSION GREATER_EQUAL 3.5.0)
   find_package(g2c 1.7.0 REQUIRED)
+else()
+  find_package(g2c 1.7.0)
+endif()
+
+# See if the g2c_compare program is available.
+find_program(G2C_COMPARE g2c_compare)
+if (G2C_COMPARE)
+  message(STATUS "g2c_compare found: ${G2C_COMPARE}")
+else()
+  message(STATUS "g2c_compare not found.")
 endif()
 
 # The name of the bacio library changed with the 2.5.0 release. The

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,10 +71,15 @@ gu_copy_test_data(ref_gdaswave.t00z.wcoast.0p16.f000_2.grib2.idx)
 # Run these shell tests.
 gu_test(run_cnvgrib_tests)
 gu_test(run_copygb_tests)
-gu_test(run_copygb2_tests)
 gu_test(run_degrib2_tests)
 gu_test(run_grbindex_tests)
 gu_test(run_grb2index_tests)
+
+# This test depends on the g2c_compare utility, which may not be
+# present.
+if (G2C_COMPARE)
+  gu_test(run_copygb2_tests)
+endif()
 
 # Does the user want to get extra test files from the FTP site, and
 # run extra tests on them?

--- a/tests/run_copygb2_tests.sh
+++ b/tests/run_copygb2_tests.sh
@@ -13,12 +13,5 @@ echo "*** Running copygb2 test"
 # Are the files the same?
 g2c_compare -v data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 test_gdaswave_2.grib2
 
-# Create an index of the copied file.
-#../src/grb2index/grb2index test_gdaswave_2.grib2 test_gdaswave_2.idx
-
-# Check against expected output. First 120 bytes contain differences,
-# so ignore them.
-#cmp -i 120 test_gdaswave_2.idx data/ref_gdaswave_2.idx
-
 echo "*** SUCCESS!"
 exit 0

--- a/tests/run_copygb2_tests.sh
+++ b/tests/run_copygb2_tests.sh
@@ -10,12 +10,15 @@ echo "*** Running copygb2 test"
 # Copy GRIB2 file.
 ../src/copygb2/copygb2 -x data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 test_gdaswave_2.grib2
 
+# Are the files the same?
+g2c_compare -v data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 test_gdaswave_2.grib2
+
 # Create an index of the copied file.
-../src/grb2index/grb2index test_gdaswave_2.grib2 test_gdaswave_2.idx
+#../src/grb2index/grb2index test_gdaswave_2.grib2 test_gdaswave_2.idx
 
 # Check against expected output. First 120 bytes contain differences,
 # so ignore them.
-cmp -i 120 test_gdaswave_2.idx data/ref_gdaswave_2.idx
+#cmp -i 120 test_gdaswave_2.idx data/ref_gdaswave_2.idx
 
 echo "*** SUCCESS!"
 exit 0

--- a/tests/run_copygb2_tests.sh
+++ b/tests/run_copygb2_tests.sh
@@ -11,7 +11,7 @@ echo "*** Running copygb2 test"
 ../src/copygb2/copygb2 -x data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 test_gdaswave_2.grib2
 
 # Are the files the same?
-g2c_compare -v data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 test_gdaswave_2.grib2
+#g2c_compare -v data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 test_gdaswave_2.grib2
 
 # Create an index of the copied file.
 #../src/grb2index/grb2index test_gdaswave_2.grib2 test_gdaswave_2.idx

--- a/tests/run_copygb2_tests.sh
+++ b/tests/run_copygb2_tests.sh
@@ -11,7 +11,7 @@ echo "*** Running copygb2 test"
 ../src/copygb2/copygb2 -x data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 test_gdaswave_2.grib2
 
 # Are the files the same?
-#g2c_compare -v data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 test_gdaswave_2.grib2
+g2c_compare -v data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 test_gdaswave_2.grib2
 
 # Create an index of the copied file.
 #../src/grb2index/grb2index test_gdaswave_2.grib2 test_gdaswave_2.idx


### PR DESCRIPTION
Part of #184.

I've introduced a new utility program in the g2c project: g2c_compare.

This utility can be used to compare outputs to ensure correctness, but without caring about what the exact offsets are. In this way, it can identify two GRIB2 files as the same, even if different versions of jasper were used, and the compressed data are different.

