### PR TITLE
fix memory problem in degrib2 - length of level abbreviation string was incorrect causing memory error

### DIFF
--- a/src/degrib2/degrib2.F90
+++ b/src/degrib2/degrib2.F90
@@ -9,15 +9,6 @@
 !>
 !> @note Command line can have only one file name.
 !>
-!> ### Program History Log
-!> Date | Programmer | Comments
-!> -----|------------|---------
-!> 2010-09-06 | Vuong | Initial
-!> 2011-10-03 | Vuong | Added to check for reference time for PDT 4.15
-!> 2012-06-07 | Vuong | Changed PRINT statement to WRITE with format specifier
-!> 2017-01-21 | Vuong | Added to check for undefine values
-!> 2022-09-06 | Hartnett | Added implicit none
-!>
 !> @return 0 for success.
 !> @author Stephen Gilbert @date 2010-09-08
 program degrib2

--- a/src/degrib2/degrib2.F90
+++ b/src/degrib2/degrib2.F90
@@ -175,8 +175,8 @@ program degrib2
         write(6, *)' Data Values:'
         write(6, '(A,I0,A,I0)')'  Num. of Data Points =  ', &
              gfld%ndpts, '   Num. of Data Undefined = ', gfld%ndpts-numpts
-        write(6, fmt = '( "( PARM= ",A," ) : ", " MIN=",f25.8," AVE=",f25.8, &
-             " MAX=",f25.8)') trim(pabbrev), fldmin, sum / numpts, fldmax
+        write(6, fmt = '( "( PARM= ",A," ) : ", " MIN=",f25.8," AVE=",f25.8, " MAX=",f25.8)') &
+             trim(pabbrev), fldmin, sum / numpts, fldmax
 
         ! Free memory allocated to hold field.
         call gf_free(gfld)

--- a/src/degrib2/degrib2.F90
+++ b/src/degrib2/degrib2.F90
@@ -25,7 +25,7 @@ program degrib2
   integer :: listsec1(13)
   character(len = 250) :: gfile1
   character(len = 8) :: pabbrev
-  character(len = 30) :: labbrev
+  character(len = 40) :: labbrev
   character(len = 90) :: tabbrev
   integer(4) narg, iargc, temparg
   integer :: currlen = 0,  numpts = 0

--- a/src/degrib2/degrib2.F90
+++ b/src/degrib2/degrib2.F90
@@ -26,7 +26,7 @@ program degrib2
   character(len = 250) :: gfile1
   character(len = 8) :: pabbrev
   character(len = 40) :: labbrev
-  character(len = 90) :: tabbrev
+  character(len = 100) :: tabbrev
   integer(4) narg, iargc, temparg
   integer :: currlen = 0,  numpts = 0
   logical :: unpack, expand

--- a/src/degrib2/prvtime.F90
+++ b/src/degrib2/prvtime.F90
@@ -24,7 +24,7 @@ subroutine prvtime(ipdtn, ipdtmpl, listsec1, tabbrev)
 
   character(len = 16) :: reftime, endtime
   character(len = 10) :: tmpval, tmpval2
-  character(len = 10) :: tunit, tunit2
+  character(len = 10) :: tunit
   integer, dimension(200) :: ipos, ipos2
   integer :: is, itemp, itemp2, iunit, iuni2t2, iunit2, iutpos, iutpos2, j
   
@@ -82,33 +82,29 @@ subroutine prvtime(ipdtn, ipdtmpl, listsec1, tabbrev)
   end select
 
   ! Determine second unit of time range.
-  iutpos2 = ipos2(ipdtn)
-  selectcase(ipdtmpl(iutpos2))
-  case (0)
-     tunit2 = "minute"
+  if (ipdtn .eq. 0) then
      iunit2 = 1
-  case (1)
-     tunit2 = "hour"
-     iunit2 = 1
-  case (2)
-     tunit2 = "day"
-     iunit2 = 1
-  case (3)
-     tunit2 = "month"
-     iuni2t2 = 1
-  case (4)
-     tunit2 = "year"
-     iunit2 = 1
-  case (10)
-     tunit2 = "hour"
-     iunit2 = 3
-  case (11)
-     tunit2 = "hour"
-     iunit2 = 6
-  case default
-     tunit2 = "hour"
-     iunit2 = 1
-  end select
+  else
+     iutpos2 = ipos2(ipdtn)
+     selectcase(ipdtmpl(iutpos2))
+     case (0)
+        iunit2 = 1
+     case (1)
+        iunit2 = 1
+     case (2)
+        iunit2 = 1
+     case (3)
+        iuni2t2 = 1
+     case (4)
+        iunit2 = 1
+     case (10)
+        iunit2 = 3
+     case (11)
+        iunit2 = 6
+     case default
+        iunit2 = 1
+     end select
+  endif
 
   write(reftime, fmt = '(i4,3i2.2,":",i2.2,":",i2.2)') (listsec1(j), j = 6, 11)
   itemp = abs (ipdtmpl(iutpos + 1)) * iunit

--- a/tests/run_degrib2_tests.sh
+++ b/tests/run_degrib2_tests.sh
@@ -10,10 +10,10 @@ echo "*** Running degrib2 test"
 # Degrib2 a GRIB2 file.
 ../src/degrib2/degrib2 data/ref_gdaswave.t00z.wcoast.0p16.f000.grib2 &> test_gdaswave.degrib2.txt
 
-echo "got:"
-cat test_gdaswave.degrib2.txt
-echo "expected:"
-cat data/ref_gdaswave.degrib2.txt
+#echo "got:"
+#cat test_gdaswave.degrib2.txt
+#echo "expected:"
+#cat data/ref_gdaswave.degrib2.txt
 
 # Check against expected output.
 diff -w test_gdaswave.degrib2.txt data/ref_gdaswave.degrib2.txt


### PR DESCRIPTION
Fixes #224 

Fixed memory problem.

This can be reviewed after #223 is merged.