### PR TITLE
Update package.py

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -32,6 +32,13 @@ jobs:
       with:
         path: grib-util
 
+    - name: cache-spack
+      id: cache-spack
+      uses: actions/cache@v3
+      with:
+        path: ~/spack-build-cache
+        key: spack-build-cache-${{ matrix.os }}-1
+
     - name: spack-build-and-test
       run: |
         git clone -c feature.manyFiles=true https://github.com/spack/spack
@@ -41,13 +48,25 @@ jobs:
         cp $GITHUB_WORKSPACE/grib-util/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/grib-util/package.py
         mv $GITHUB_WORKSPACE/grib-util $SPACK_ENV/grib-util
         spack develop --no-clone grib-util@develop
-        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.5.0 ^w3emc@2.10.0 ^g2@3.4.6 ^g2c@develop ^ip@4.1.0 ^sp@2.3.3
+        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.5.0 ^w3emc@2.10.0 ^g2@3.4.6 ^g2c@develop ^ip@4.2.0 ^sp@2.4.0
         spack external find cmake gmake
+        spack mirror add spack-build-cache ~/spack-build-cache
         spack concretize
         # Run installation and run CTest suite
-        spack install --verbose --fail-fast --test root
+        spack install --fail-fast --no-check-signature --test root
+        # Print test results
+        cat $(spack location -i grib-util)/.spack/install-time-test-log.txt
         # Run 'spack load' to check for obvious errors in setup_run_environment
+        echo "Loading grib-util through Spack..."
         spack load grib-util
+        spack buildcache push --only dependencies --unsigned ~/spack-build-cache grib-util
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.openmp }}
+        path: ${{ github.workspace }}/grib-util/spack-build-*/Testing/Temporary/LastTest.log
 
   # This job validates the Spack recipe by making sure each cmake build option is represented
   recipe-check:

--- a/spack/package.py
+++ b/spack/package.py
@@ -33,8 +33,10 @@ class GribUtil(CMakePackage):
     depends_on("g2c@1.7: +utils")
     depends_on("bacio")
     depends_on("ip")
+    depends_on("ip precision=d", when="ip@4.1:")
     depends_on("ip@:3.3.3", when="@:1.2")
     depends_on("sp")
+    depends_on("sp precision=d", when="sp@2.4:")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
copygb and copygb2 use ip_d and no other ip precision setting, so this PR updates the spack recipe to reflect that. Also, adding build caching in the Spack CI.

Fixes #278
Fixes #277

regular merge