### PR TITLE
taking out g2c

### DIFF
--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -179,7 +179,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/g2
-        key: g2-${{ runner.os }}-${{ matrix.g2-version }}-1
+        key: g2-${{ runner.os }}-${{ matrix.g2-version }}-${{ matrix.jasper-version }}-${{ matrix.bacio-version }}-${{ matrix.w3emc-version }}-1
 
     - name: checkout-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,8 @@ find_package(sp 2.3.3 REQUIRED)
 find_package(ip 3.3.3 REQUIRED)
 find_package(w3emc 2.10.0 REQUIRED)
 find_package(g2 3.4.0 REQUIRED)
-if (g2_VERSION GREATER_EQUAL 3.5.0)
-  find_package(g2c 1.7.0 REQUIRED)
-else()
-  find_package(g2c 1.7.0)
-endif()
+# g2c is not required.
+#find_package(g2c 1.7.0)
 
 # The name of the bacio library changed with the 2.5.0 release. The
 # "_4" was removed from the library and include directory name in the


### PR DESCRIPTION
Taking out use of g2c before the next release. It is only used in some testing.