### PR TITLE
ip v5 updates

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -91,13 +91,13 @@ jobs:
     - name: cache-sp
       id: cache-sp
       uses: actions/cache@v3
-      if: matrix.ip_version == 'v4.5.0'
+      if: matrix.ip_version == 'v4.4.0'
       with:
         path: ~/sp
         key: sp-Intel-${{ matrix.compilers }}-${{ runner.os }}-v2.4.0
 
     - name: checkout-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.ip_version == 'v4.5.0'
+      if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.ip_version == 'v4.4.0'
       uses: actions/checkout@v3
       with:
         repository: NOAA-EMC/NCEPLIBS-sp
@@ -105,7 +105,7 @@ jobs:
         ref: v2.4.0
 
     - name: build-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.ip_version == 'v4.5.0'
+      if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.ip_version == 'v4.4.0'
       run: |
         cd sp
         mkdir build

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         compilers: ["CC=icc FC=ifort", "CC=icx FC=ifx"]
+        ip_version: ["v5.0.0", "v4.5.0"]
 
     steps:
 
@@ -90,12 +91,13 @@ jobs:
     - name: cache-sp
       id: cache-sp
       uses: actions/cache@v3
+      if: matrix.ip_version == 'v4.5.0'
       with:
         path: ~/sp
         key: sp-Intel-${{ matrix.compilers }}-${{ runner.os }}-v2.4.0
 
     - name: checkout-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true'
+      if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.ip_version == 'v4.5.0'
       uses: actions/checkout@v3
       with:
         repository: NOAA-EMC/NCEPLIBS-sp
@@ -103,7 +105,7 @@ jobs:
         ref: v2.4.0
 
     - name: build-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true'
+      if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.ip_version == 'v4.5.0'
       run: |
         cd sp
         mkdir build
@@ -142,7 +144,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/ip
-        key: ip-Intel-${{ matrix.compilers }}-${{ runner.os }}-v4.3.0
+        key: ip-Intel-${{ matrix.compilers }}-${{ runner.os }}-${{ matrix.ip_version }}
 
     - name: checkout-ip
       if: steps.cache-ip.outputs.cache-hit != 'true'
@@ -150,7 +152,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-ip
         path: ip
-        ref: v4.3.0
+        ref: ${{ matrix.ip_version }}
 
     - name: build-ip
       if: steps.cache-ip.outputs.cache-hit != 'true'

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         compilers: ["CC=icc FC=ifort", "CC=icx FC=ifx"]
-        ip_version: ["v5.0.0", "v4.5.0"]
+        ip_version: ["v5.0.0", "v4.4.0"]
 
     steps:
 

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -37,7 +37,7 @@ jobs:
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        sudo apt-get install intel-oneapi-openmp intel-oneapi-compiler-fortran-2023.2.1 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.2.1
         echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
       
     - name: cache-jasper

--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -22,8 +22,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        sp-version: [2.3.3]
-        ip-version: [4.1.0]
+        ip-version: [5.0.0]
         g2-version: [3.4.8]
         bacio-version: [2.6.0]
         jasper-version: [2.0.33, 3.0.5, 4.0.0]
@@ -83,31 +82,6 @@ jobs:
         make -j2
         make install
 
-    - name: cache-sp
-      id: cache-sp
-      uses: actions/cache@v3
-      with:
-        path: ~/sp
-        key: sp-${{ runner.os }}-${{ matrix.sp-version }}
-
-    - name: checkout-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: NOAA-EMC/NCEPLIBS-sp
-        path: sp
-        ref: v${{ matrix.sp-version }}
-
-    - name: build-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true'
-      run: |
-        cd sp
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/sp
-        make -j2
-        make install
-          
     - name: cache-w3emc
       id: cache-w3emc
       uses: actions/cache@v3
@@ -154,7 +128,7 @@ jobs:
         cd ip
         mkdir build
         cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/ip -DCMAKE_PREFIX_PATH=~/sp
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/ip
         make -j2
         make install
           
@@ -179,7 +153,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/g2
-        key: linux_external_g2-${{ runner.os }}-${{ matrix.g2-version }}-${{ matrix.jasper-version }}-${{ matrix.bacio-version }}-${{ matrix.w3emc-version }}-${{ matrix.ip-version }}-${{ matrix.sp-version }}-3
+        key: linux_external_g2-${{ runner.os }}-${{ matrix.g2-version }}-${{ matrix.jasper-version }}-${{ matrix.bacio-version }}-${{ matrix.w3emc-version }}-${{ matrix.ip-version }}-3
 
     - name: checkout-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'
@@ -210,6 +184,6 @@ jobs:
         mkdir build && cd build
         export LD_LIBRARY_PATH=/home/runner/jasper/lib
         export PATH="~/g2c/bin:$PATH"
-        cmake -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/sp;~/ip;~/w3emc;~/g2;~/g2c" ..
+        cmake -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/ip;~/w3emc;~/g2;~/g2c" ..
         make -j2 VERBOSE=1
         ctest --output-on-failure --rerun-failed --verbose

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -33,6 +33,12 @@ jobs:
           ip-version: 5.0.0
         - sp-version: 2.4.0
           ip-version: 5.0.0
+        - sp-version: null
+          ip-version: 3.3.3
+        - sp-version: null
+          ip-version: 4.1.0
+        - sp-version: null
+          ip-version: 4.2.0
 
     steps:
     - name: install-dependencies

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -108,7 +108,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-sp
         path: sp
-        ref: matrix.sp-version
+        ref: ${{ matrix.sp-version }}
 
     - name: build-sp
       if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.sp-version != 'null'
@@ -158,7 +158,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-ip
         path: ip
-        ref: matrix.ip-version
+        ref: ${{ matrix.ip-version }}
 
     - name: build-ip
       if: steps.cache-ip.outputs.cache-hit != 'true'

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -26,19 +26,19 @@ jobs:
         bacio-version: [2.4.1, 2.5.0, 2.6.0]
         jasper-version: [4.0.0]
         w3emc-version: [2.10.0, 2.11.0]
-        sp-version: [2.3.3, 2.4.0, null]
-        ip-version: [3.3.3, 4.1.0, 4.2.0, 5.0.0]
+        sp-version: [v2.3.3, v2.4.0, null]
+        ip-version: [v3.3.3, v4.1.0, v4.2.0, v5.0.0]
         exclude:
-          - sp-version: 2.3.3
-            ip-version: 5.0.0
-          - sp-version: 2.4.0
-            ip-version: 5.0.0
+          - sp-version: v2.3.3
+            ip-version: v5.0.0
+          - sp-version: v2.4.0
+            ip-version: v5.0.0
           - sp-version: null
-            ip-version: 3.3.3
+            ip-version: v3.3.3
           - sp-version: null
-            ip-version: 4.1.0
+            ip-version: v4.1.0
           - sp-version: null
-            ip-version: 4.2.0
+            ip-version: v4.2.0
 
     steps:
     - name: install-dependencies
@@ -108,7 +108,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-sp
         path: sp
-        ref: v${{ matrix.sp-version }}
+        ref: matrix.sp-version
 
     - name: build-sp
       if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.sp-version != 'null'
@@ -158,7 +158,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-ip
         path: ip
-        ref: v${{ matrix.ip-version }}
+        ref: matrix.ip-version
 
     - name: build-ip
       if: steps.cache-ip.outputs.cache-hit != 'true'

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -26,8 +26,13 @@ jobs:
         bacio-version: [2.4.1, 2.5.0, 2.6.0]
         jasper-version: [4.0.0]
         w3emc-version: [2.10.0, 2.11.0]
-        sp-version: [2.3.3, 2.4.0]
-        ip-version: [3.3.3, 4.1.0, 4.2.0]
+        sp-version: [2.3.3, 2.4.0, null]
+        ip-version: [3.3.3, 4.1.0, 4.2.0, 5.0.0]
+      exclude:
+        - sp-version: 2.3.3
+          ip-version: 5.0.0
+        - sp-version: 2.4.0
+          ip-version: 5.0.0
 
     steps:
     - name: install-dependencies
@@ -86,12 +91,13 @@ jobs:
     - name: cache-sp
       id: cache-sp
       uses: actions/cache@v3
+      if: matrix.sp-version != 'null'
       with:
         path: ~/sp
         key: sp-${{ runner.os }}-${{ matrix.sp-version }}
 
     - name: checkout-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true'
+      if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.sp-version != 'null'
       uses: actions/checkout@v3
       with:
         repository: NOAA-EMC/NCEPLIBS-sp
@@ -99,7 +105,7 @@ jobs:
         ref: v${{ matrix.sp-version }}
 
     - name: build-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true'
+      if: steps.cache-sp.outputs.cache-hit != 'true' && matrix.sp-version != 'null'
       run: |
         cd sp
         mkdir build

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -28,17 +28,17 @@ jobs:
         w3emc-version: [2.10.0, 2.11.0]
         sp-version: [2.3.3, 2.4.0, null]
         ip-version: [3.3.3, 4.1.0, 4.2.0, 5.0.0]
-      exclude:
-        - sp-version: 2.3.3
-          ip-version: 5.0.0
-        - sp-version: 2.4.0
-          ip-version: 5.0.0
-        - sp-version: null
-          ip-version: 3.3.3
-        - sp-version: null
-          ip-version: 4.1.0
-        - sp-version: null
-          ip-version: 4.2.0
+        exclude:
+          - sp-version: 2.3.3
+            ip-version: 5.0.0
+          - sp-version: 2.4.0
+            ip-version: 5.0.0
+          - sp-version: null
+            ip-version: 3.3.3
+          - sp-version: null
+            ip-version: 4.1.0
+          - sp-version: null
+            ip-version: 4.2.0
 
     steps:
     - name: install-dependencies

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -23,11 +23,11 @@ jobs:
       fail-fast: true
       matrix:
         g2-version: [3.4.8]
-        bacio-version: [2.4.1, 2.5.0, 2.6.0]
+        bacio-version: [2.4.1, 2.6.0]
         jasper-version: [4.0.0]
         w3emc-version: [2.10.0, 2.11.0]
         sp-version: [v2.3.3, v2.4.0, null]
-        ip-version: [v3.3.3, v4.1.0, v4.2.0, v5.0.0]
+        ip-version: [v3.3.3, v4.4.0, v5.0.0]
         exclude:
           - sp-version: v2.3.3
             ip-version: v5.0.0
@@ -36,9 +36,7 @@ jobs:
           - sp-version: null
             ip-version: v3.3.3
           - sp-version: null
-            ip-version: v4.1.0
-          - sp-version: null
-            ip-version: v4.2.0
+            ip-version: v4.4.0
 
     steps:
     - name: install-dependencies

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -71,31 +71,6 @@ jobs:
         cmake .. -DCMAKE_INSTALL_PREFIX=~/bacio
         make -j2
         make install
-
-    - name: cache-sp
-      id: cache-sp
-      uses: actions/cache@v3
-      with:
-        path: ~/sp
-        key: sp-${{ runner.os }}-2.4.0
-
-    - name: checkout-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: NOAA-EMC/NCEPLIBS-sp
-        path: sp
-        ref: v2.4.0
-
-    - name: build-sp
-      if: steps.cache-sp.outputs.cache-hit != 'true'
-      run: |
-        cd sp
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/sp
-        make -j2
-        make install
           
     - name: cache-w3emc
       id: cache-w3emc
@@ -127,7 +102,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/ip
-        key: ip-MacOS-${{ runner.os }}-4.2.0
+        key: ip-MacOS-${{ runner.os }}-5.0.0
 
     - name: checkout-ip
       if: steps.cache-ip.outputs.cache-hit != 'true'
@@ -135,7 +110,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-ip
         path: ip
-        ref: v4.2.0
+        ref: v5.0.0
 
     - name: build-ip
       if: steps.cache-ip.outputs.cache-hit != 'true'
@@ -143,7 +118,7 @@ jobs:
         cd ip
         mkdir build
         cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/ip -DCMAKE_PREFIX_PATH=~/sp
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/ip
         make -j2
         make install
           
@@ -181,6 +156,6 @@ jobs:
       run: |
         cd grib_utils
         mkdir build && cd build
-        cmake -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/sp;~/ip;~/w3emc;~/g2" ..
+        cmake -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/ip;~/w3emc;~/g2" ..
         make -j2
         ctest --output-on-failure --rerun-failed --verbose

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         openmp: ["+openmp", "~openmp"]
+        ip_spec: ["^ip@5.0.0", "^ip@4.2.0 ^sp@2.4.0"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -37,7 +38,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/spack-build-cache
-        key: spack-build-cache-${{ matrix.os }}-1
+        key: spack-build-cache-${{ matrix.os }}-${{ matrix.ip_spec }}1
 
     - name: spack-build-and-test
       run: |
@@ -48,7 +49,7 @@ jobs:
         cp $GITHUB_WORKSPACE/grib-util/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/grib-util/package.py
         mv $GITHUB_WORKSPACE/grib-util $SPACK_ENV/grib-util
         spack develop --no-clone grib-util@develop
-        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.6.0 ^w3emc@2.10.0 ^g2@3.4.8 ^g2c@develop ^ip@4.2.0 ^sp@2.4.0
+        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.6.0 ^w3emc@2.10.0 ^g2@3.4.8 ^g2c@develop ${{ ip_spec }}
         spack external find cmake gmake
         spack mirror add spack-build-cache ~/spack-build-cache
         spack concretize

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -49,7 +49,7 @@ jobs:
         cp $GITHUB_WORKSPACE/grib-util/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/grib-util/package.py
         mv $GITHUB_WORKSPACE/grib-util $SPACK_ENV/grib-util
         spack develop --no-clone grib-util@develop
-        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.6.0 ^w3emc@2.10.0 ^g2@3.4.8 ^g2c@develop ${{ ip_spec }}
+        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.6.0 ^w3emc@2.10.0 ^g2@3.4.8 ^g2c@develop ${{ matrix.ip_spec }}
         spack external find cmake gmake
         spack mirror add spack-build-cache ~/spack-build-cache
         spack concretize

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -47,8 +47,7 @@ jobs:
         spack env create grib-util-env
         spack env activate grib-util-env
         cp $GITHUB_WORKSPACE/grib-util/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/grib-util/package.py
-        mv $GITHUB_WORKSPACE/grib-util $SPACK_ENV/grib-util
-        spack develop --no-clone grib-util@develop
+        spack develop --no-clone --path $GITHUB_WORKSPACE/grib-util grib-util@develop
         spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.6.0 ^w3emc@2.10.0 ^g2@3.4.8 ^g2c@develop ${{ matrix.ip_spec }}
         spack external find cmake gmake
         spack mirror add spack-build-cache ~/spack-build-cache

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/spack-build-cache
-        key: spack-build-cache-${{ matrix.os }}-${{ matrix.ip_spec }}1
+        key: spack-build-cache-${{ matrix.os }}-${{ matrix.ip_spec }}-1
 
     - name: spack-build-and-test
       run: |

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -48,7 +48,7 @@ jobs:
         spack env activate grib-util-env
         cp $GITHUB_WORKSPACE/grib-util/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/grib-util/package.py
         spack develop --no-clone --path $GITHUB_WORKSPACE/grib-util grib-util@develop
-        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.6.0 ^w3emc@2.10.0 ^g2@3.4.8 ^g2c@develop ${{ matrix.ip_spec }}
+        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.6.0 ^w3emc@2.10.0 ^g2@3.4.8 ^g2c@develop +utils +build_v2_api ${{ matrix.ip_spec }}
         spack external find cmake gmake
         spack mirror add spack-build-cache ~/spack-build-cache
         spack concretize

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -94,7 +94,7 @@ jobs:
         cd ip
         mkdir build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=~/ip
+        cmake -DCMAKE_INSTALL_PREFIX=~/ip ..
         make -j2
         make install
           

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -65,22 +65,6 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=~/bacio ..
         make -j2
         make install
-
-    - name: checkout-sp
-      uses: actions/checkout@v3
-      with:
-        repository: NOAA-EMC/NCEPLIBS-sp
-        path: sp
-        ref: develop
-
-    - name: build-sp
-      run: |
-        cd sp
-        mkdir build
-        cd build
-        cmake -DCMAKE_INSTALL_PREFIX=~/sp ..
-        make -j2
-        make install
           
     - name: checkout-w3emc
       uses: actions/checkout@v3
@@ -110,7 +94,7 @@ jobs:
         cd ip
         mkdir build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=~/ip -DCMAKE_PREFIX_PATH=~/sp ..
+        cmake -DCMAKE_INSTALL_PREFIX=~/ip
         make -j2
         make install
           
@@ -161,7 +145,7 @@ jobs:
         ls -l ~/jasper/lib
         export LD_LIBRARY_PATH=/home/runner/jasper/lib
         export PATH="~/g2c/bin:$PATH"
-        cmake -DENABLE_DOCS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/sp;~/ip;~/w3emc;~/g2;~/g2c" -DCMAKE_Fortran_FLAGS="-fprofile-arcs -ftest-coverage -O0 -Wall" -DCMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage -O0 -Wall" -DG2C_COMPARE=ON ..
+        cmake -DENABLE_DOCS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="~/bacio;~/jasper;~/ip;~/w3emc;~/g2;~/g2c" -DCMAKE_Fortran_FLAGS="-fprofile-arcs -ftest-coverage -O0 -Wall" -DCMAKE_C_FLAGS="-fprofile-arcs -ftest-coverage -O0 -Wall" -DG2C_COMPARE=ON ..
         make -j2 VERBOSE=1
         ctest --output-on-failure --rerun-failed --verbose
 

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -110,7 +110,7 @@ jobs:
         cd g2c
         mkdir build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=~/g2c -DCMAKE_PREFIX_PATH="~/jasper" ..
+        cmake -DCMAKE_INSTALL_PREFIX=~/g2c -DCMAKE_PREFIX_PATH="~/jasper" -DBUILD_G2C=ON ..
         make -j2
         make install
                  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ file(STRINGS "VERSION" pVersion)
 project(gributil VERSION ${pVersion} LANGUAGES C Fortran)
 
 # Handle user options.
-option(OPENMP "use OpenMP threading" OFF)
+option(OPENMP "Use OpenMP threading" OFF)
 option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
 option(FTP_TEST_FILES "Fetch and test with files on FTP site." OFF)
 option(FTP_LARGE_TEST_FILES "Fetch and test with very large files on FTP site." OFF)
@@ -39,8 +39,10 @@ find_package(ZLIB REQUIRED)
 
 # Find the NCEPLIBS libraries we need.
 find_package(bacio 2.4.0 REQUIRED)
-find_package(sp 2.3.3 REQUIRED)
 find_package(ip 3.3.3 REQUIRED)
+if(ip_VERSION LESS 5.0)
+  find_package(sp 2.3.3 REQUIRED)
+endif()
 find_package(w3emc 2.10.0 REQUIRED)
 find_package(g2 3.4.8 REQUIRED)
 # g2c is not required.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Repository | Notes
 -----------|------
 [NCEPLIBS-bacio](https://github.com/NOAA-EMC/NCEPLIBS-bacio) | binary I/O for NCEP models
 [NCEPLIBS-ip](https://github.com/NOAA-EMC/NCEPLIBS-ip) | interpolating between NCEP grids
-[NCEPLIBS-sp](https://github.com/NOAA-EMC/NCEPLIBS-sp) | spectral transform functions - only needed for ip v4 and lower
+[NCEPLIBS-sp](https://github.com/NOAA-EMC/NCEPLIBS-sp) | spectral transform functions - only needed for NCEPLIBS-ip v4 and below
 [NCEPLIBS-g2](https://github.com/NOAA-EMC/NCEPLIBS-g2) | Fortran implementation of the GRIB 2 functions
 [NCEPLIBS-w3emc](https://github.com/NOAA-EMC/NCEPLIBS-w3emc) | GRIB1 library
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Project | Notes
 Repository | Notes
 -----------|------
 [NCEPLIBS-bacio](https://github.com/NOAA-EMC/NCEPLIBS-bacio) | binary I/O for NCEP models
-[NCEPLIBS-sp](https://github.com/NOAA-EMC/NCEPLIBS-sp) | spectral transform functions
 [NCEPLIBS-ip](https://github.com/NOAA-EMC/NCEPLIBS-ip) | interpolating between NCEP grids
+[NCEPLIBS-sp](https://github.com/NOAA-EMC/NCEPLIBS-sp) | spectral transform functions - only needed for ip v4 and lower
 [NCEPLIBS-g2](https://github.com/NOAA-EMC/NCEPLIBS-g2) | Fortran implementation of the GRIB 2 functions
 [NCEPLIBS-w3emc](https://github.com/NOAA-EMC/NCEPLIBS-w3emc) | GRIB1 library
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -31,7 +31,7 @@ class GribUtil(CMakePackage):
     depends_on("w3emc precision=4,d", when="^w3emc@2.10:")
     depends_on("w3nco", when="@:1.2.3")
     depends_on("g2")
-    depends_on("g2c@develop +utils", when="+tests")
+    depends_on("g2c@1.8: +utils", when="+tests")
     depends_on("bacio")
     depends_on("ip")
     depends_on("ip precision=d", when="^ip@4.1:")

--- a/spack/package.py
+++ b/spack/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -25,24 +25,23 @@ class GribUtil(CMakePackage):
 
     depends_on("jasper")
     depends_on("libpng")
-    depends_on("zlib")
+    depends_on("zlib-api")
     depends_on("w3emc +extradeps", when="@1.2.4:")
     depends_on("w3emc precision=4,d", when="^w3emc@2.10:")
     depends_on("w3nco", when="@:1.2.3")
     depends_on("g2")
-    depends_on("g2c@1.7: +utils")
     depends_on("bacio")
     depends_on("ip")
-    depends_on("ip precision=d", when="ip@4.1:")
+    depends_on("ip precision=d", when="^ip@4.1:")
     depends_on("ip@:3.3.3", when="@:1.2")
-    depends_on("sp")
-    depends_on("sp precision=d", when="sp@2.4:")
+    depends_on("sp", when="^ip@:4")
+    depends_on("sp precision=d", when="^ip@:4 ^sp@2.4:")
 
     def cmake_args(self):
         args = [
             self.define_from_variant("OPENMP", "openmp"),
             self.define("BUILD_TESTING", self.run_tests),
-            self.define("G2C_COMPARE", self.run_tests),
+            self.define("G2C_COMPARE", False),
         ]
         return args
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -22,6 +22,7 @@ class GribUtil(CMakePackage):
     version("1.2.3", sha256="b17b08e12360bb8ad01298e615f1b4198e304b0443b6db35fe990a817e648ad5")
 
     variant("openmp", default=False, description="Use OpenMP multithreading")
+    variant("tests", default=False, description="Enable this variant when installing with --test")
 
     depends_on("jasper")
     depends_on("libpng")
@@ -30,6 +31,7 @@ class GribUtil(CMakePackage):
     depends_on("w3emc precision=4,d", when="^w3emc@2.10:")
     depends_on("w3nco", when="@:1.2.3")
     depends_on("g2")
+    depends_on("g2c@develop +utils", when="+tests")
     depends_on("bacio")
     depends_on("ip")
     depends_on("ip precision=d", when="^ip@4.1:")
@@ -41,7 +43,7 @@ class GribUtil(CMakePackage):
         args = [
             self.define_from_variant("OPENMP", "openmp"),
             self.define("BUILD_TESTING", self.run_tests),
-            self.define("G2C_COMPARE", False),
+            self.define("G2C_COMPARE", self.run_tests),
         ]
         return args
 

--- a/src/copygb/CMakeLists.txt
+++ b/src/copygb/CMakeLists.txt
@@ -18,7 +18,10 @@ set(fortran_src copygb.F90)
 # Build the executable.
 set(exe_name copygb)
 add_executable(${exe_name} ${fortran_src})
-target_link_libraries(${exe_name} PRIVATE bacio::${bacio_name} w3emc::w3emc_d ip::ip_d sp::sp_d)
+target_link_libraries(${exe_name} PRIVATE bacio::${bacio_name} w3emc::w3emc_d ip::ip_d)
+if(ip_VERSION LESS 5.0)
+  target_link_libraries(${exe_name} PRIVATE sp::sp_d)
+endif()
 
 # Use openMP if found.
 if(OpenMP_Fortran_FOUND)

--- a/src/copygb2/CMakeLists.txt
+++ b/src/copygb2/CMakeLists.txt
@@ -24,8 +24,11 @@ target_link_libraries(${exe_name} PRIVATE
   ${JASPER_LIBRARIES}
   bacio::${bacio_name}
   w3emc::w3emc_d
-  ip::ip_d
-  sp::sp_d)
+  ip::ip_d)
+
+if(ip_VERSION LESS 5.0)
+  target_link_libraries(${exe_name} PRIVATE sp::sp_d)
+endif()
 
 # If OpenMP is available, use it.
 if(OpenMP_Fortran_FOUND)


### PR DESCRIPTION
This PR updates grib-util to allow the use of ip v5 (i.e., ip with sp merged), and tests several versions throughout the CI (sp is still tested).