### PR TITLE
changed workflows to use g2 develop branch for final testing before release

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -169,7 +169,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/g2
-        key: g2-Intel-${{ matrix.compilers }}-${{ runner.os }}-develop-1
+        key: g2-Intel-${{ matrix.compilers }}-${{ runner.os }}-develop-2
 
     - name: checkout-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'

--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -153,7 +153,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/g2
-        key: linux_external_g2-${{ runner.os }}-${{ matrix.g2-version }}-${{ matrix.jasper-version }}-${{ matrix.bacio-version }}-${{ matrix.w3emc-version }}-${{ matrix.ip-version }}-3
+        key: linux_external_g2-${{ runner.os }}-${{ matrix.g2-version }}-${{ matrix.jasper-version }}-${{ matrix.bacio-version }}-${{ matrix.w3emc-version }}-${{ matrix.ip-version }}-4
 
     - name: checkout-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'
@@ -161,7 +161,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-g2
         path: g2
-        ref: v${{ matrix.g2-version }}
+        ref: develop
 
     - name: build-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'      

--- a/.github/workflows/Linux_external.yml
+++ b/.github/workflows/Linux_external.yml
@@ -148,15 +148,15 @@ jobs:
         make -j2
         make install
                  
-    - name: cache-g2
-      id: cache-g2
-      uses: actions/cache@v3
-      with:
-        path: ~/g2
-        key: linux_external_g2-${{ runner.os }}-${{ matrix.g2-version }}-${{ matrix.jasper-version }}-${{ matrix.bacio-version }}-${{ matrix.w3emc-version }}-${{ matrix.ip-version }}-4
+    # - name: cache-g2
+    #   id: cache-g2
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: ~/g2
+    #     key: linux_external_g2-${{ runner.os }}-${{ matrix.g2-version }}-${{ matrix.jasper-version }}-${{ matrix.bacio-version }}-${{ matrix.w3emc-version }}-${{ matrix.ip-version }}-4
 
     - name: checkout-g2
-      if: steps.cache-g2.outputs.cache-hit != 'true'
+#      if: steps.cache-g2.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
       with:
         repository: NOAA-EMC/NCEPLIBS-g2
@@ -164,7 +164,7 @@ jobs:
         ref: develop
 
     - name: build-g2
-      if: steps.cache-g2.outputs.cache-hit != 'true'      
+ #     if: steps.cache-g2.outputs.cache-hit != 'true'      
       run: |
         cd g2
         mkdir build

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -184,15 +184,15 @@ jobs:
         make -j2
         make install
                  
-    - name: cache-g2
-      id: cache-g2
-      uses: actions/cache@v3
-      with:
-        path: ~/g2
-        key: g2-${{ runner.os }}-${{ matrix.bacio-version }}-${{ matrix.jasper-version }}-${{ matrix.w3emc-version }}-${{ matrix.g2-version }}-2
+    # - name: cache-g2
+    #   id: cache-g2
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: ~/g2
+    #     key: g2-${{ runner.os }}-${{ matrix.bacio-version }}-${{ matrix.jasper-version }}-${{ matrix.w3emc-version }}-${{ matrix.g2-version }}-2
 
     - name: checkout-g2
-      if: steps.cache-g2.outputs.cache-hit != 'true'
+#      if: steps.cache-g2.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
       with:
         repository: NOAA-EMC/NCEPLIBS-g2
@@ -200,7 +200,7 @@ jobs:
         ref: develop
 
     - name: build-g2
-      if: steps.cache-g2.outputs.cache-hit != 'true'
+#      if: steps.cache-g2.outputs.cache-hit != 'true'
       run: |
         cd g2
         mkdir build

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -189,7 +189,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/g2
-        key: g2-${{ runner.os }}-${{ matrix.bacio-version }}-${{ matrix.jasper-version }}-${{ matrix.w3emc-version }}-${{ matrix.g2-version }}
+        key: g2-${{ runner.os }}-${{ matrix.bacio-version }}-${{ matrix.jasper-version }}-${{ matrix.w3emc-version }}-${{ matrix.g2-version }}-2
 
     - name: checkout-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'
@@ -197,7 +197,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-g2
         path: g2
-        ref: v${{ matrix.g2-version }}
+        ref: develop
 
     - name: build-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -127,7 +127,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/g2
-        key: g2-MacOS-${{ runner.os }}-4.0.0-2.6.0-3.4.8
+        key: g2-MacOS-${{ runner.os }}-4.0.0-2.6.0-develop
 
     - name: checkout-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'
@@ -135,7 +135,7 @@ jobs:
       with:
         repository: NOAA-EMC/NCEPLIBS-g2
         path: g2
-        ref: v3.4.8
+        ref: develop
 
     - name: build-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -122,12 +122,12 @@ jobs:
         make -j2
         make install
           
-    - name: cache-g2
-      id: cache-g2
-      uses: actions/cache@v3
-      with:
-        path: ~/g2
-        key: g2-MacOS-${{ runner.os }}-4.0.0-2.6.0-develop
+    # - name: cache-g2
+    #   id: cache-g2
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: ~/g2
+    #     key: g2-MacOS-${{ runner.os }}-4.0.0-2.6.0-develop
 
     - name: checkout-g2
       if: steps.cache-g2.outputs.cache-hit != 'true'

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -48,7 +48,7 @@ jobs:
         spack env activate grib-util-env
         cp $GITHUB_WORKSPACE/grib-util/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/grib-util/package.py
         spack develop --no-clone --path $GITHUB_WORKSPACE/grib-util grib-util@develop
-        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.6.0 ^w3emc@2.10.0 ^g2@3.4.8 ^g2c@develop +utils +build_v2_api ${{ matrix.ip_spec }}
+        spack add grib-util@develop%gcc@11 ${{ matrix.openmp }} ^bacio@2.6.0 ^w3emc@2.10.0 ^g2@develop ^g2c@develop +utils +build_v2_api ${{ matrix.ip_spec }}
         spack external find cmake gmake
         spack mirror add spack-build-cache ~/spack-build-cache
         spack concretize


### PR DESCRIPTION
In this PR I temporarily change the workflows so that the develop branch of g2 is used everywhere. This is final testing for the next g2/grib_util release. After the release I will change the workflows again.