### PR TITLE
now require g2-3.4.9 in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ if(ip_VERSION LESS 5.0)
   find_package(sp 2.3.3 REQUIRED)
 endif()
 find_package(w3emc 2.10.0 REQUIRED)
-find_package(g2 3.4.8 REQUIRED)
+find_package(g2 3.4.9 REQUIRED)
 # g2c is not required.
 #find_package(g2c 1.7.0)
 


### PR DESCRIPTION
Part of #310 

We need the latest version of the g2 library to support the new index format.